### PR TITLE
fix: manifest description

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -116,9 +116,9 @@ module.exports = require('./webpack.base.babel')({
     }),
 
     new WebpackPwaManifest({
-      name: 'React Boilerplate',
-      short_name: 'React BP',
-      description: 'My React Boilerplate-based project!',
+      name: 'yearn.finance',
+      short_name: 'yearn',
+      description: 'numba go up',
       background_color: '#fafafa',
       theme_color: '#b1624d',
       inject: true,


### PR DESCRIPTION
when user installs pwa app on mobile, it says React BP under the icon (from the React BoilerPlate being used).

This fixes it by replacing the description with yearn, should also fix it on splash screen
