### PR TITLE
fix: add loading feedback on vaults

### DIFF
--- a/app/components/ConnectButton/index.js
+++ b/app/components/ConnectButton/index.js
@@ -10,7 +10,7 @@ import ConnectedAccount from './ConnectedAccount';
 const StyledButton = styled.button(() => [
   tw`
   rounded-xl border-2 border-yearn-blue px-4
-  items-center justify-center align-middle 
+  items-center justify-center align-middle
   flex hover:text-yearn-blue py-1
   uppercase
   `,
@@ -35,7 +35,7 @@ export default function ConnectButton(props) {
     content = (
       <StyledButton className={className} onClick={selectWallet}>
         <p tw="font-sans">
-          Launch App
+          Connect wallet
           {/* <FormattedMessage id="account.connect" /> */}
         </p>
       </StyledButton>

--- a/app/components/CoverCard/index.js
+++ b/app/components/CoverCard/index.js
@@ -8,6 +8,7 @@ import {
 } from 'utils/string';
 import Icon from 'components/Icon';
 import { Link } from 'react-router-dom';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 const Wrapper = styled(Link)`
   height: 312px;
@@ -185,7 +186,11 @@ export default function CoverCard(props) {
   let cardContent;
   let protocolUrlEl;
   if (!claimTokenBalanceOf) {
-    cardContent = <Middle>Loading...</Middle>;
+    cardContent = (
+      <Middle>
+        <CircularProgress color="white" />
+      </Middle>
+    );
   } else {
     protocolUrlEl = (
       <ProtocolUrl href={`https://${protocolUrl}`} target="_blank">

--- a/app/containers/Vaults/index.js
+++ b/app/containers/Vaults/index.js
@@ -13,6 +13,8 @@ import VaultsNavLinks from 'components/VaultsNavLinks';
 import { useShowDevVaults } from 'containers/Vaults/hooks';
 import AddVault from 'components/AddVault';
 import AccordionContext from 'react-bootstrap/AccordionContext';
+import { useWallet, useAccount } from 'containers/ConnectionProvider/hooks';
+import LinearProgress from '@material-ui/core/LinearProgress';
 
 const Wrapper = styled.div`
   width: 1088px;
@@ -44,7 +46,9 @@ const DevHeader = styled.div`
 const Vaults = () => {
   const devMode = true;
   const showDevVaults = useShowDevVaults();
-
+  const wallet = useWallet();
+  const account = useAccount();
+  const walletConnected = wallet.provider && account;
   let columnHeader;
   if (showDevVaults) {
     columnHeader = <VaultsHeaderDev />;
@@ -65,14 +69,17 @@ const Vaults = () => {
       {warning}
       {columnHeader}
       <Accordion>
-        <VaultsWrapper showDevVaults={showDevVaults} />
+        <VaultsWrapper
+          showDevVaults={showDevVaults}
+          walletConnected={walletConnected}
+        />
       </Accordion>
     </Wrapper>
   );
 };
 
 const VaultsWrapper = props => {
-  const { showDevVaults } = props;
+  const { showDevVaults, walletConnected } = props;
   const orderedVaults = useSelector(selectOrderedVaults);
   const localContracts = useSelector(selectContractsByTag('localContracts'));
   const currentEventKey = useContext(AccordionContext);
@@ -84,6 +91,9 @@ const VaultsWrapper = props => {
       showDevVaults={showDevVaults}
     />
   );
+
+  // Show Linear progress when orderedvaults is empty
+  if (walletConnected && orderedVaults == null) return <LinearProgress />;
 
   let vaultRows = _.map(orderedVaults, renderVault);
   if (showDevVaults) {


### PR DESCRIPTION
This PR adds/changes the following:
- Change Launch app to Connect wallet on Top bar.
- Add linear progress feedback when wallet is connected and vault list is empty.
- Use Circular loader for cover cards when loading data