### PR TITLE
feat: add lattice1 support

### DIFF
--- a/app/containers/ConnectionProvider/services.js
+++ b/app/containers/ConnectionProvider/services.js
@@ -17,6 +17,11 @@ export function initOnboard(subscriptions, darkMode) {
       wallets: [
         { walletName: 'metamask' },
         {
+          walletName: 'lattice',
+          appName: 'Yearn Finance',
+          rpcUrl,
+        },
+        {
           walletName: 'trezor',
           appUrl: 'https://reactdemo.blocknative.com',
           email: 'aaron@blocknative.com',


### PR DESCRIPTION
**Background**
The Lattice1 is GridPlus' next generation Ethereum-focused programmable hardware wallet. It is an always-online device with physically separated secure compute and Linux general compute environments. For more information, see https://gridplus.io/

**About this PR**
This PR adds the Lattice1 to the list of available wallets via Blocknative Onboard v1.18.0, which is currently used by Yearn and fully supports the Lattice1.

The Lattice1 can load smart contract ABIs so that interactions with your contracts are human-readable on the touchscreen which is drawn using the secure compute environment. This can help prevent man-in-the-middle attacks even when your computer is compromised. You can learn more about this functionality in [this blog post](https://blog.gridplus.io/readable-ethereum-transactions-a-new-standard-945c5e9ef2c7) and please let us know if you're interested in us preloading the Yearn Finance ABIs via an upcoming Lattice1 firmware release.

Thanks and please let us know if you have any questions!