### PR TITLE
fix(v2-vaults): display N/A for apy (tmp change)

### DIFF
--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -178,13 +178,15 @@ const Vault = (props) => {
 
   const vaultName = displayName || name || address;
 
+  const v2Vault = vault.type === 'v2' || vault.apiVersion;
+
   const apyOneMonthSample = _.get(vault, 'apy.oneMonthSample');
-  const apy = truncateApy(apyOneMonthSample);
+  // FIXME: temporary fix till apy in the API is calculated correctly
+  const apy = truncateApy(!v2Vault ? apyOneMonthSample : undefined);
   const tokenBalanceOf = new BigNumber(tokenBalance)
     .dividedBy(10 ** decimals)
     .toFixed();
 
-  const v2Vault = vault.type === 'v2' || vault.apiVersion;
   let vaultBalanceOf;
   if (v2Vault) {
     vaultBalanceOf = new BigNumber(balanceOf)


### PR DESCRIPTION
yearn API isn't reporting a correct apy for v2 vaults. until we figure
out what is the issue we need to prevent user from seeing wrong
calculations.
