### PR TITLE
Button optimizations

### DIFF
--- a/app/components/ButtonFilled/index.js
+++ b/app/components/ButtonFilled/index.js
@@ -24,6 +24,13 @@ export default function ButtonFilled(props) {
         backgroundColor: color === 'secondary' ? '#999' : '#0657F9',
       },
       textAlign: 'center',
+      '&.Mui-disabled': {
+        opacity: 0.5,
+        backgroundColor: color === 'secondary' ? '#999' : '#0657F9',
+        color: color === 'secondary' ? '#333' : '#fff',
+        cursor: 'not-allowed',
+        pointerEvents: 'auto',
+      },
     },
   }))(Button);
 

--- a/app/components/ButtonFilled/index.js
+++ b/app/components/ButtonFilled/index.js
@@ -1,11 +1,21 @@
 import React from 'react';
-
+import Tooltip from '@material-ui/core/Tooltip';
 import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
 import { useShowDevVaults } from 'containers/Vaults/hooks';
 
 export default function ButtonFilled(props) {
-  const { onClick, disabled, children, type, title, onSubmit, color } = props;
+  const {
+    onClick,
+    disabled,
+    children,
+    type,
+    title,
+    onSubmit,
+    color,
+    tooltipText,
+    showTooltip,
+  } = props;
   const showDevVaults = useShowDevVaults();
 
   const ColorButton = withStyles(() => ({
@@ -34,6 +44,30 @@ export default function ButtonFilled(props) {
     },
   }))(Button);
 
+  if (disabled && showTooltip) {
+    console.log('tooltip text', tooltipText);
+    const adjustedButtonProps = {
+      disabled,
+      component: disabled ? 'div' : undefined,
+      onClick: disabled ? undefined : onClick,
+    };
+    return (
+      <Tooltip title={tooltipText}>
+        <ColorButton
+          variant="contained"
+          title={title}
+          color={color}
+          onClick={onClick}
+          onSubmit={onSubmit}
+          type={type}
+          disabled={disabled}
+          {...adjustedButtonProps}
+        >
+          {children}
+        </ColorButton>
+      </Tooltip>
+    );
+  }
   return (
     <ColorButton
       variant="contained"

--- a/app/components/ButtonFilled/index.js
+++ b/app/components/ButtonFilled/index.js
@@ -45,7 +45,6 @@ export default function ButtonFilled(props) {
   }))(Button);
 
   if (disabled && showTooltip) {
-    console.log('tooltip text', tooltipText);
     const adjustedButtonProps = {
       disabled,
       component: disabled ? 'div' : undefined,
@@ -55,7 +54,6 @@ export default function ButtonFilled(props) {
       <Tooltip title={tooltipText}>
         <ColorButton
           variant="contained"
-          title={title}
           color={color}
           onClick={onClick}
           onSubmit={onSubmit}

--- a/app/components/VaultControls/index.js
+++ b/app/components/VaultControls/index.js
@@ -84,10 +84,6 @@ export default function VaultControls(props) {
     setWithdrawalGweiAmount(0);
   }, [walletBalance, vaultBalance]);
 
-  if (!vaultContract || !tokenContract) {
-    return null;
-  }
-
   const withdraw = () => {
     console.log(`Withdrawing:`, withdrawalGweiAmount);
     dispatch(
@@ -129,6 +125,7 @@ export default function VaultControls(props) {
             handler={withdraw}
             text="Withdraw"
             title="Withdraw from vault"
+            disabled={!vaultContract || !tokenContract}
           />
         </ButtonGroup>
       </ActionGroup>
@@ -146,6 +143,7 @@ export default function VaultControls(props) {
             handler={deposit}
             text={tokenAllowance || pureEthereum > 0 ? 'Deposit' : 'Approve'}
             title="Deposit into vault"
+            disabled={!vaultContract || !tokenContract}
           />
         </ButtonGroup>
       </ActionGroup>
@@ -215,9 +213,14 @@ function Balance({ amount, prefix }) {
   );
 }
 
-function ActionButton({ handler, title, text }) {
+function ActionButton({ handler, title, text, disabled }) {
   return (
-    <ButtonFilled onClick={() => handler()} color="primary" title={title}>
+    <ButtonFilled
+      onClick={() => handler()}
+      color="primary"
+      title={title}
+      disabled={disabled}
+    >
       {text}
     </ButtonFilled>
   );

--- a/app/components/VaultControls/index.js
+++ b/app/components/VaultControls/index.js
@@ -126,6 +126,7 @@ export default function VaultControls(props) {
             text="Withdraw"
             title="Withdraw from vault"
             disabled={!vaultContract || !tokenContract}
+            showTooltip
           />
         </ButtonGroup>
       </ActionGroup>
@@ -144,6 +145,7 @@ export default function VaultControls(props) {
             text={tokenAllowance || pureEthereum > 0 ? 'Deposit' : 'Approve'}
             title="Deposit into vault"
             disabled={!vaultContract || !tokenContract}
+            showTooltip
           />
         </ButtonGroup>
       </ActionGroup>
@@ -213,13 +215,15 @@ function Balance({ amount, prefix }) {
   );
 }
 
-function ActionButton({ handler, title, text, disabled }) {
+function ActionButton({ handler, title, text, disabled, showTooltip }) {
   return (
     <ButtonFilled
       onClick={() => handler()}
       color="primary"
       title={title}
       disabled={disabled}
+      tooltipText={`Connect your wallet to ${title}`}
+      showTooltip={showTooltip}
     >
       {text}
     </ButtonFilled>


### PR DESCRIPTION
https://github.com/iearn-finance/yearn-finance/issues/94

- Show Vault Withdraw and Deposit Buttons even if wallet isn't connected by overriding Mui Style for disabled buttons to address 0.5 opacity change & cursor not-allowed
- Parameters of showTooltip and tooltipText can be passed in to change what text appears
