### PR TITLE
Fix/apy tooltip

### DIFF
--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -260,16 +260,16 @@ const Vault = (props) => {
         <TooltipTable>
           <tbody>
             <tr>
-              <td>Boost</td>
-              <td>{apy.data.currentBoost.toFixed(2)}x</td>
+              <td>Pool APY</td>
+              <td>{truncateApy(apy.data.poolApy)}</td>
             </tr>
             <tr>
               <td>Base CRV APY</td>
               <td>{truncateApy(apy.data.baseApy)}</td>
             </tr>
             <tr>
-              <td>Pool APY</td>
-              <td>{truncateApy(apy.data.poolApy)}</td>
+              <td>Boost</td>
+              <td>{apy.data.currentBoost.toFixed(2)}x</td>
             </tr>
             <tr>
               <td>Total APY</td>

--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -124,7 +124,7 @@ const InfoIcon = styled(Icon)`
 
 const Apy = styled.div`
   display: inline-block;
-  width: 65px;
+  width: 73px;
 `;
 
 const TooltipTable = styled.table`

--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -261,7 +261,7 @@ const Vault = (props) => {
           <tbody>
             <tr>
               <td>Boost</td>
-              <td>{apy.data.currentBoost}x</td>
+              <td>{apy.data.currentBoost.toFixed(2)}x</td>
             </tr>
             <tr>
               <td>Base CRV APY</td>


### PR DESCRIPTION
Fixes:
```
.Truncate boost value on hover to two decimals, currently shows way too many
.Fix tooltip APY spacing (100%+ is too far over for USDN)
.On that same note, if we could reorder the appearance of the data in the Curve vault hover so it reads:
   Pool APY + CRV Boosted APY
   Pool APY xx%
   Base CRV APY xx%
   Boost xx
   Total APY xx%
```