### PR TITLE
fix: base apy for usdn vault

### DIFF
--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -135,19 +135,19 @@ const TooltipTable = styled.table`
   }
 `;
 
-// const Notice = styled.div`
-//   padding: 1em 0;
-//   display: flex;
-//   justify-content: center;
-//   width: 100%;
-// `;
+const Notice = styled.div`
+  padding: 1em 0;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+`;
 
-// const NoticeIcon = styled(Icon)`
-//   height: 1.2em;
-//   position: relative;
-//   cursor: pointer;
-//   margin: 0 0.8em;
-// `;
+const NoticeIcon = styled(Icon)`
+  height: 1.2em;
+  position: relative;
+  cursor: pointer;
+  margin: 0 0.8em;
+`;
 
 const StyledText = styled(Text)`
   cursor: pointer;
@@ -619,6 +619,15 @@ const Vault = (props) => {
                 <span>Your tokens can be safely withdrawn, now</span>
               </Notice>
             )} */}
+            {['crvUSDN'].includes(vaultName) && (
+              <Notice>
+                <NoticeIcon type="info" />
+                <span>
+                  80% of USDN CRV harvest is locked to boost yield. APY
+                  displayed reflects this.
+                </span>
+              </Notice>
+            )}
             {backscratcherInfo}
             <Card.Footer className={active && 'active'}>
               <Footer>{vaultControls}</Footer>

--- a/app/containers/App/selectors.js
+++ b/app/containers/App/selectors.js
@@ -186,10 +186,12 @@ export const selectOrderedVaults = createSelector(
         const updatedVault = vault;
         updatedVault.apy.data = {
           ...vault.apy.data,
-          baseApy: 0.2,
-          boostedApy: 0.2 * vault.apy.data.currentBoost,
+          baseApy: vault.apy.data.baseApy * 0.2,
+          boostedApy:
+            vault.apy.data.baseApy * 0.2 * vault.apy.data.currentBoost,
           totalApy:
-            0.2 * 0.2 * vault.apy.data.currentBoost + vault.apy.data.poolApy,
+            vault.apy.data.baseApy * 0.2 * vault.apy.data.currentBoost +
+            vault.apy.data.poolApy,
         };
         updatedVault.apy.recommended = updatedVault.apy.data.totalApy;
         return updatedVault;

--- a/app/containers/App/selectors.js
+++ b/app/containers/App/selectors.js
@@ -175,10 +175,28 @@ export const selectOrderedVaults = createSelector(
   selectContracts('vaults'),
   (vaults, vaultsContractData) => {
     // Remove non-endorsed v2 vaults
-    const filteredVaults = _.filter(
+    let filteredVaults = _.filter(
       vaults,
       (vault) => !(vault.type === 'v2' && vault.endorsed === false),
     );
+
+    // TODO: REMOVE WHEN crvUSDN APY DATA IS CORRECT
+    filteredVaults = filteredVaults.map((vault) => {
+      if (vault.displayName === 'crvUSDN') {
+        const updatedVault = vault;
+        updatedVault.apy.data = {
+          ...vault.apy.data,
+          baseApy: 0.2,
+          boostedApy: 0.2 * vault.apy.data.currentBoost,
+          totalApy:
+            0.2 * 0.2 * vault.apy.data.currentBoost + vault.apy.data.poolApy,
+        };
+        updatedVault.apy.recommended = updatedVault.apy.data.totalApy;
+        return updatedVault;
+      }
+
+      return vault;
+    });
 
     // If no contract data is available sort by vault version
     if (_.isUndefined(vaultsContractData) || _.isEmpty(vaultsContractData)) {


### PR DESCRIPTION
- Temporary fix for:

>  Manually update displayed USDN APY for now since we're pulling 80% for backscratcher
 Add disclaimer in drop-down menu for USDN as well like we had for DAI after hack. Something like 80% of USDN CRV yield is deposited to yveCRV. APY of ~20% is accurate after accounting for this.

from https://github.com/iearn-finance/iearn-finance/issues/247

Note: Remove after a permanent fix is implemented.