### PR TITLE
feat: vault links

### DIFF
--- a/app/components/Vault/index.js
+++ b/app/components/Vault/index.js
@@ -20,6 +20,7 @@ import Icon from 'components/Icon';
 import { useModal } from 'containers/ModalProvider/hooks';
 import Text from 'components/Text';
 import Box from 'components/Box';
+
 // import tw from 'twin.macro';
 
 // const formatVaultStatistic = stat => {
@@ -624,43 +625,44 @@ const Vault = (props) => {
   }
   return (
     <React.Fragment>
-      <Card className={active && 'active'}>
-        <Accordion.Toggle
-          as={Card.Header}
-          variant="link"
-          eventKey={accordionKey}
-        >
-          {vaultTop}
-          {/* {vaultStats} */}
-          <StyledText fontWeight={600} mr={32}>
-            {active ? 'HIDE' : 'SHOW'}
-          </StyledText>
-        </Accordion.Toggle>
-        <Accordion.Collapse eventKey={accordionKey}>
-          <Card.Body>
-            {vaultBottom}
-            {/* {['DAI', 'WETH', 'Ethereum'].includes(vaultName) && !v2Vault && (
-              <Notice>
-                <NoticeIcon type="info" />
-                <span>Your tokens can be safely withdrawn, now</span>
-              </Notice>
-            )} */}
-            {['crvUSDN'].includes(vaultName) && (
-              <Notice>
-                <NoticeIcon type="info" />
-                <span>
-                  50% of USDN CRV harvest is locked to boost yield. APY
-                  displayed reflects this.
-                </span>
-              </Notice>
-            )}
-            {backscratcherInfo}
-            <Card.Footer className={active && 'active'}>
-              <Footer>{vaultControls}</Footer>
-            </Card.Footer>
-          </Card.Body>
-        </Accordion.Collapse>
-      </Card>
+        <Card className={active && 'active'} id={`vault-${accordionKey}`}>
+          <Accordion.Toggle
+            as={Card.Header}
+            variant="link"
+            eventKey={accordionKey}
+          >
+            {vaultTop}
+            {/* {vaultStats} */}
+            <StyledText fontWeight={600} mr={32}>
+              {active ? 'HIDE' : 'SHOW'}
+            </StyledText>
+          </Accordion.Toggle>
+          <Accordion.Collapse eventKey={accordionKey}>
+            <Card.Body>
+              {vaultBottom}
+              {/* {['DAI', 'WETH', 'Ethereum'].includes(vaultName) && !v2Vault && (
+                <Notice>
+                  <NoticeIcon type="info" />
+                  <span>Your tokens can be safely withdrawn, now</span>
+                </Notice>
+              )} */}
+              {['crvUSDN'].includes(vaultName) && (
+                <Notice>
+                  <NoticeIcon type="info" />
+                  <span>
+                    50% of USDN CRV harvest is locked to boost yield. APY
+                    displayed reflects this.
+                  </span>
+                </Notice>
+              )}
+              {backscratcherInfo}
+              <Card.Footer className={active && 'active'}>
+                <Footer>{vaultControls}</Footer>
+              </Card.Footer>
+            </Card.Body>
+          </Accordion.Collapse>
+        </Card>
+      
     </React.Fragment>
   );
 };

--- a/app/containers/Vaults/index.js
+++ b/app/containers/Vaults/index.js
@@ -21,6 +21,7 @@ import { useWallet, useAccount } from 'containers/ConnectionProvider/hooks';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import BigNumber from 'bignumber.js';
 
+
 const Wrapper = styled.div`
   margin: 0 auto;
   margin-top: 20px;
@@ -101,7 +102,8 @@ const useSortableData = (items, config = null) => {
   return { items: sortedItems, requestSort, sortConfig };
 };
 
-const Vaults = () => {
+const Vaults = (props) => {
+  const { history } = props;
   const showDevVaults = useShowDevVaults();
   const wallet = useWallet();
   const account = useAccount();
@@ -174,6 +176,19 @@ const Vaults = () => {
     requestSort('valueDeposited');
   }, []);
 
+  // Show the vault based on URL path
+  const pathArray = history.location.pathname.split('/');
+  const showAccordionKey = pathArray[2] || '';
+
+  useEffect(() => {
+    // Scroll to the vault
+    if ( showAccordionKey ) {
+      const anchor = `vault-${showAccordionKey}`;
+      const el = document.getElementById(anchor);
+      if ( el ) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  });
+
   let columnHeader;
   let backscratcherWrapper;
   if (showDevVaults) {
@@ -200,6 +215,11 @@ const Vaults = () => {
       </WrapTable>
     );
   }
+  
+  const linkToVault = (accordionKey) => {
+    const path = accordionKey || '';
+    history.push(`/vaults/${path}`);
+  }
 
   return (
     <Wrapper>
@@ -211,7 +231,7 @@ const Vaults = () => {
       {backscratcherWrapper}
       <WrapTable>
         {columnHeader}
-        <StyledAccordion>
+        <StyledAccordion onSelect={linkToVault} defaultActiveKey={showAccordionKey}>
           <VaultsWrapper
             vaultItems={items}
             showDevVaults={showDevVaults}


### PR DESCRIPTION
@x48-crypto This should resolve #183 

* Each vault is now associated with a URL address e.g. `/vaults/0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c`
* Expanding each vault also scrolls to center of screen `el.scrollIntoView({ behavior: 'smooth', block: 'center' })`

A potential future enhancement would be to support this for the `backscratcher` vault.